### PR TITLE
Correction for properly run in macosx snow leopard

### DIFF
--- a/book
+++ b/book
@@ -10,7 +10,7 @@
  * file that was distributed with this source code.
  */
 
-require __DIR__.'/vendor/.composer/autoload.php';
+require __DIR__.'/vendor/autoload.php';
 
 use Easybook\DependencyInjection\Application;
 use Easybook\Console\ConsoleApplication;

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,9 @@
         "symfony/finder":           "2.1.*",
         "symfony/yaml":             "2.1.*",
 
-        "twig/twig":                "1.6.*"
+        "twig/twig":                "1.6.*",
+        "symfony/dependency-injection": "dev-master",
+        "symfony/http-kernel": "dev-master"
     },
 
     "autoload": {


### PR DESCRIPTION
There was wrong path in line 13 on book file.
I added also two extensions to composer.json because it was suggested by installer.
