### PR TITLE
incorrect .composer in ./book

### DIFF
--- a/book
+++ b/book
@@ -10,7 +10,7 @@
  * file that was distributed with this source code.
  */
 
-require __DIR__.'/vendor/.composer/autoload.php';
+require __DIR__.'/vendor/autoload.php';
 
 use Easybook\DependencyInjection\Application;
 use Easybook\Console\ConsoleApplication;


### PR DESCRIPTION
I followed the tutorial, line by line and had an error when trying to launch "book". It appears that autoload.php is in vendor, not vendor/.composer.

This branch solves the problem.
