### PR TITLE
Call MarkdownExtra_Parser instead of Markdown_Parser to preserve backward compatibility

### DIFF
--- a/src/Easybook/Parsers/MarkdownParser.php
+++ b/src/Easybook/Parsers/MarkdownParser.php
@@ -104,7 +104,7 @@ class MarkdownEasybookParser extends \MarkdownExtra_Parser
         $this->app = $app;
         $this->app->set('publishing.active_item.toc', array());
 
-        parent::Markdown_Parser();
+        parent::MarkdownExtra_Parser();
     }
 
     /**


### PR DESCRIPTION
I think calling Markdown_Parser instead of MarkdownExtra_Parser it is a typo, because the class extends MarkdownExtra_Parser but never calls the extra method. Anywary, it breaks backward compatibility because in previous versions the extra parser was used.
