### PR TITLE
Epub: refresh global Twig variable 'edition' to allow templates to pick 'edition.id' value

### DIFF
--- a/src/Easybook/Publishers/Epub2Publisher.php
+++ b/src/Easybook/Publishers/Epub2Publisher.php
@@ -63,6 +63,11 @@ class Epub2Publisher extends HtmlPublisher
         // set the edition id needed for ebook generation
         $this->app->edition('id', $this->app['publishing.id']);
 
+        // refresh global Twig variable 'edition' to allow templates to pick 'edition.id' value
+        $publishingEdition = $this->app['publishing.edition'];
+        $editions = $this->app->book('editions');
+        $this->app->get('twig')->addGlobal('edition', $editions[$publishingEdition]);
+        
         // variables needed to hold the list of images and fonts of the book
         $bookImages = array();
         $bookFonts  = array();


### PR DESCRIPTION
Twig template variable `edition.id` is assigned in assembleBook() but it was not available in template `content.opf.twig` because `edition` was assigned previously as a global Twig variable that was not being refreshed.

This PR refreshes the value of the global `edition` Twig variable just after `edition.id`  gets assigned.
