### PR TITLE
correct images label when there is a title

### DIFF
--- a/src/Easybook/Plugins/ImagePlugin.php
+++ b/src/Easybook/Plugins/ImagePlugin.php
@@ -54,7 +54,7 @@ class ImagePlugin implements EventSubscriberInterface
             //   2. <div class="(left OR center OR right)">
             //        <img (...optional...) alt="..." (...optional...) />
             //      </div>
-            '/(<p>)?(<div class="(?<align>.*)">)?(?<content><img .*alt="(?<title>.*)".*\/>)(<\/div>)?(<\/p>)?/',
+            '/(<p>)?(<div class="(?<align>.*)">)?(?<content><img .*alt="(?<title>[^"]*)".*\/>)(<\/div>)?(<\/p>)?/',
             function($matches) use ($event, $elementNumber, &$listOfImages, &$counter) {
                 // prepare item parameters for template and label
                 $counter++;


### PR DESCRIPTION
since regexp is parsed in greedy mode, @title attribute was captured by
`alt="(?<title>.*).`
the new regexp stops at first `"`.
