### PR TITLE
Epub: Do not replace the item slug with the generated filename 

### DIFF
--- a/src/Easybook/Publishers/Epub2Publisher.php
+++ b/src/Easybook/Publishers/Epub2Publisher.php
@@ -111,11 +111,10 @@ class Epub2Publisher extends HtmlPublisher
                 ? $item['config']['element'].' '.$item['config']['number']
                 : $item['config']['element'];
 
-            $slug = $this->app->get('slugger')->slugify(trim($pageName));
+            $fileName = $this->app->get('slugger')->slugify(trim($pageName));
 
-            $item['slug'] = $slug;
             // TODO: document this new item property
-            $item['fileName'] = $slug.'.html';
+            $item['fileName'] = $fileName.'.html';
             $items[] = $item;
         }
         // update `publishing items` with the new slug value


### PR DESCRIPTION
Epub2Publisher generates an unique name for each book 'chunk' when publishing it, instead of using the item slug (to avoid ridiculously long filenames).  For example, for an item with title "My chapter with a long title" it generates a file named something linke "chapter-3.html" instead of "my-chapter-with-a-long-title.html"

But it also replaced the item slug with the generated filename, so the new slug for the item would be "chapter-3". This was causing problems when you wanted to make an internal link to the item because linking to "#my-chapter-with-a-long-title" would not work (you should use a link to "#chapter-3" instead, thus precluding the usage of the item id).

This PR makes the internal links work as intended (using the item slug)  without modifying the file naming schema.
