### PR TITLE
Solve issue #110

### DIFF
--- a/src/Easybook/Publishers/Epub2Publisher.php
+++ b/src/Easybook/Publishers/Epub2Publisher.php
@@ -274,7 +274,7 @@ class Epub2Publisher extends HtmlPublisher
                 ? $item['config']['element'].' '.$item['config']['number']
                 : $item['config']['element'];
 
-            $item['page_name'] = $this->app->slugify($itemPageName);
+            $item['page_name'] = $this->app->slugifyUniquely($itemPageName);
 
             $itemsWithNormalizedPageNames[] = $item;
         }


### PR DESCRIPTION
Currently, name of different book parts are not unique in an epub, leading to incomplete epubs.

This simple patch solves this using slugifyUniquely
