### PR TITLE
Fixed 'force page breaks' syntax for PrinceXML

### DIFF
--- a/app/Resources/Themes/Base/Pdf/Templates/css/items.css.twig
+++ b/app/Resources/Themes/Base/Pdf/Templates/css/items.css.twig
@@ -49,6 +49,11 @@
 .item.appendix h2 {
     string-set: appendix_section content();
 }
+
+.page-break {
+    display: block;
+    page-break-after: always;
+}
 {% endblock %}
 {% block acknowledgement %}
 /* @acknowledgement


### PR DESCRIPTION
PrinceXML would not compile page breaks with the 'force page break' syntax ( `{pagebreak}` or `<!--BREAK-->`).

[PrinceXML's page break properties can be applied to block-level elements, table rows and table row groups that occur within an in-flow element.](http://www.princexml.com/doc/9.0/page-breaks/)

Since easybook's page break implementation is [`<br class="page-break" />`](https://github.com/javiereguiluz/easybook/commit/467763314d48d2b7d9f1beff1555430bd46ec5f7), I changed class `.page-break` to a block-level element with `display: block;`.

I added `page-break-after: always;` so PrinceXML will always page break after the use of the syntax.
