### PR TITLE
New parameter to configure the book output name.

### DIFF
--- a/src/Easybook/DependencyInjection/Application.php
+++ b/src/Easybook/DependencyInjection/Application.php
@@ -79,6 +79,7 @@ class Application extends \Pimple
         $this['publishing.active_item']     = array();
         $this['publishing.active_item.toc'] = array();
         $this['publishing.book.config']     = array('book' => array());
+        $this['publishing.book.output']     = 'book';
         $this['publishing.book.slug']       = '';
         $this['publishing.book.items']      = array();
         // the real TOC used to generate the book (needed for html_chunked editions)

--- a/src/Easybook/Publishers/Epub2Publisher.php
+++ b/src/Easybook/Publishers/Epub2Publisher.php
@@ -152,9 +152,10 @@ class Epub2Publisher extends HtmlPublisher
 
         // compress book contents as ZIP file and rename to .epub
         $this->zipBookContents($bookTmpDir.'/book', $bookTmpDir.'/book.zip');
+        $epubFilePath = sprintf("%s/%s.epub", $this->app['publishing.dir.output'], $this->app['publishing.book.output']);
         $this->app['filesystem']->copy(
             $bookTmpDir.'/book.zip',
-            $this->app['publishing.dir.output'].'/book.epub',
+            $epubFilePath,
             true
         );
 

--- a/src/Easybook/Publishers/HtmlChunkedPublisher.php
+++ b/src/Easybook/Publishers/HtmlChunkedPublisher.php
@@ -58,7 +58,7 @@ class HtmlChunkedPublisher extends HtmlPublisher
 
     public function assembleBook()
     {
-        $this->app['publishing.dir.output'] = $this->app['publishing.dir.output'].'/book';
+        $this->app['publishing.dir.output']  .= '/' . $this->app['publishing.book.output'];
         $this->app['filesystem']->mkdir($this->app['publishing.dir.output']);
 
         // generate easybook CSS file

--- a/src/Easybook/Publishers/HtmlPublisher.php
+++ b/src/Easybook/Publishers/HtmlPublisher.php
@@ -41,13 +41,14 @@ class HtmlPublisher extends BasePublisher
         }
 
         // implode all the contents to create the whole book
+        $htmlFilePath = sprintf("%s/%s.html", $this->app['publishing.dir.output'], $this->app['publishing.book.output']);
         $this->app->render(
             'book.twig',
             array(
                 'items'          => $this->app['publishing.items'],
                 'has_custom_css' => $hasCustomCss
             ),
-            $this->app['publishing.dir.output'].'/book.html'
+            $htmlFilePath
         );
 
 

--- a/src/Easybook/Publishers/MobiPublisher.php
+++ b/src/Easybook/Publishers/MobiPublisher.php
@@ -40,11 +40,12 @@ class MobiPublisher extends Epub2Publisher
     {
         parent::assembleBook();
 
-        $epubFilePath = $this->app['publishing.dir.output'].'/book.epub';
+        $epubFilePath = sprintf ("%s/%s.epub", $this->app['publishing.dir.output'], $this->app['publishing.book.output']);
 
-        $command = sprintf("%s %s -o book.mobi %s",
+        $command = sprintf("%s %s -o %s.mobi %s",
             $this->app['kindlegen.path'],
             $this->app['kindlegen.command_options'],
+            $this->app['publishing.book.output'],
             $epubFilePath
         );
 

--- a/src/Easybook/Publishers/PdfPublisher.php
+++ b/src/Easybook/Publishers/PdfPublisher.php
@@ -91,7 +91,7 @@ class PdfPublisher extends BasePublisher
         }
 
         $errorMessages = array();
-        $pdfBookFilePath = $this->app['publishing.dir.output'].'/book.pdf';
+        $pdfBookFilePath = sprintf("%s/%s.pdf", $this->app['publishing.dir.output'], $this->app['publishing.book.output']);
         $prince->convert_file_to_file($htmlBookFilePath, $pdfBookFilePath, $errorMessages);
         $this->displayPdfConversionErrors($errorMessages);
 


### PR DESCRIPTION
When publishing a book, the result is a file or a directory called book (plus the file extension). Added a new parameter ‘publishing.book.output’ to change the default value (as described on issue #125).
