### PR TITLE
Fix Duplicate Class Attribute (XHTML Error Syntax Fix)

### DIFF
--- a/src/Easybook/Plugins/LinkPlugin.php
+++ b/src/Easybook/Plugins/LinkPlugin.php
@@ -137,7 +137,13 @@ class LinkPlugin implements EventSubscriberInterface
         $item['content'] = preg_replace_callback(
             '/<a (href="#.*".*)<\/a>/Us',
             function ($matches) {
-                return sprintf('<a class="internal" %s</a>', $matches[1]);
+                // First check if there is an existing class attribute before
+                // adding a new class attribute and breaking the XHTML syntax
+                if (preg_match('/\bclass="(.*)"/Us', $matches[1]) !== false) {
+                    return '<a ' . preg_replace('/\bclass="(.*)"/Us', 'class="internal $1"', $matches[1]);
+                } else {
+                    return sprintf('<a class="internal" %s</a>', $matches[1]);
+                }
             },
             $item['content']
         );

--- a/src/Easybook/Publishers/Epub2Publisher.php
+++ b/src/Easybook/Publishers/Epub2Publisher.php
@@ -484,7 +484,14 @@ class Epub2Publisher extends HtmlPublisher
                         $newUri = $matches['uri'];
                     }
 
-                    return sprintf('<a class="internal" href="%s"%s</a>', $newUri, $matches[2]);
+                    // First check if there is an existing class attribute before
+                    // adding a new class attribute and breaking the XHTML syntax
+                    if (preg_match('/\bclass="(.*)"/Us', $matches[1]) !== false) {
+                        $matches[2] = preg_replace('/\bclass="(.*)"/Us', 'class="internal $1"', $matches[2]);
+                        return sprintf('<a href="%s"%s</a>', $newUri, $matches[2]);
+                    } else {
+                        return sprintf('<a class="internal" href="%s"%s</a>', $newUri, $matches[2]);
+                    }
                 },
                 $htmlContent
             );


### PR DESCRIPTION
The internal link plugin and Epub2 publisher add a `class="internal"` attribute to all links. This causes an XHTML error if the link already has a class attribute. This patch fixes this issue by checking if a class attribute exists first, and prepends the "internal" class to the existing attribute.

**Input:**
````md
Example line with a footnote[^1].
[^1]: http://www.example.com
````

**Output (Before):**
````html
<sup id="fnref:1"><a class="internal" href="#fn:1" class="footnote-ref">1</a></sup>
````

**Output (After):**
````html
<sup id="fnref:1"><a href="#fn:1" class="internal footnote-ref">1</a></sup>
````
**Error Message in iBooks:**
> This page contains the following errors:
error on line 416 at column 111: Attribute class redefined
Below is a rendering of the page up to the first error.

**Screenshot:**
<img width="466" alt="screen shot 2016-06-08 at 2 05 34 pm" src="https://cloud.githubusercontent.com/assets/3330/15907281/1b935f78-2d82-11e6-9d81-349cc13f274f.png">