### PR TITLE
Avoid errors publishing print and kindle books on windows computers

### DIFF
--- a/src/Easybook/Providers/KindleGenServiceProvider.php
+++ b/src/Easybook/Providers/KindleGenServiceProvider.php
@@ -27,6 +27,7 @@ class KindleGenServiceProvider implements ServiceProviderInterface
             '/usr/bin/kindlegen',
             # Windows
             'c:\KindleGen\kindlegen',
+            'c:\KindleGen\kindlegen.exe',
         );
 
         // -c0: no compression

--- a/src/Easybook/Providers/PrinceXMLServiceProvider.php
+++ b/src/Easybook/Providers/PrinceXMLServiceProvider.php
@@ -26,6 +26,7 @@ class PrinceXMLServiceProvider implements ServiceProviderInterface
             '/usr/local/bin/prince',                         # Mac OS X
             '/usr/bin/prince',                               # Linux
             'C:\Program Files\Prince\engine\bin\prince.exe',  # Windows
+            'C:\Program Files (x86)\Prince\engine\bin\prince.exe', # Windows
         );
 
         $app['prince'] = function () use ($app) {


### PR DESCRIPTION
Adding this two lines avoid problems using Easybook on windows.